### PR TITLE
remove credential usage for STIX bundle

### DIFF
--- a/stix-shifter-notebooks/cbr-hunt-certutil-using-cb-stix-bundle.ipynb
+++ b/stix-shifter-notebooks/cbr-hunt-certutil-using-cb-stix-bundle.ipynb
@@ -24,7 +24,6 @@
    "source": [
     "from pyclient.stix_shifter_dataframe import StixShifterDataFrame\n",
     "from dateutil import parser\n",
-    "import huntlib\n",
     "import re\n",
     "import pandas as pd"
    ]
@@ -33,27 +32,9 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Username: demo\n",
-      "Password: ········\n"
-     ]
-    }
-   ],
-   "source": [
-    "usr, psw = huntlib.util.promptCreds()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
    "outputs": [],
    "source": [
-    "carbon_black_stix_bundle_1 = 'https://raw.githubusercontent.com/opencybersecurityalliance/stix-shifter/develop/data/cybox/carbon_black/carbon_black_observable.json'\n",
+    "carbon_black_stix_bundle_1 = 'https://raw.githubusercontent.com/opencybersecurityalliance/stix-shifter/9036575784c08300c699685a17f5675e122e275f/data/cybox/carbon_black/carbon_black_observable.json'\n",
     "sb_config_1 = {\n",
     "    'translation_module': 'stix_bundle',\n",
     "    'transmission_module': 'stix_bundle',\n",
@@ -63,8 +44,8 @@
     "    },\n",
     "    'configuration': {\n",
     "        \"auth\": {\n",
-    "            \"username\": usr,\n",
-    "            \"password\": psw\n",
+    "            \"username\": None,\n",
+    "            \"password\": None\n",
     "        }\n",
     "    },\n",
     "    'data_source': '{\"type\": \"identity\", \"id\": \"identity--3532c56d-ea72-48be-a2ad-1a53f4c9c6d3\", \"name\": \"stix_boundle\", \"identity_class\": \"events\"}'\n",
@@ -73,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,8 +68,8 @@
     "    },\n",
     "    'configuration': {\n",
     "        \"auth\": {\n",
-    "            \"username\": usr,\n",
-    "            \"password\": psw\n",
+    "            \"username\": None,\n",
+    "            \"password\": None\n",
     "        }\n",
     "    },\n",
     "    'data_source': '{\"type\": \"identity\", \"id\": \"identity--3532c56d-ea72-48be-a2ad-1a53f4c9c6d3\", \"name\": \"stix_boundle\", \"identity_class\": \"events\"}'\n",
@@ -97,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -136,7 +117,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "ssdf = StixShifterDataFrame()\n",
@@ -148,13 +134,7 @@
     "# See http://docs.oasis-open.org/cti/stix/v2.0/cs01/part5-stix-patterning/stix-v2.0-cs01-part5-stix-patterning.html\n",
     "cmd_query = \"[process:name = 'cmd.exe']\"\n",
     "df = ssdf.search_df(query=cmd_query, config_names=['cb_stix_bundle_1', 'cb_stix_bundle_2'])"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
This PR contains the following changes:
- remove credential usage example for STIX bundle
- change the link that point to the STIX bundle data.